### PR TITLE
Very minor documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ray functions have a `r` prefix: `rmul`, `rdiv`, `rpow`.
 Return `x + y` or an exception in case of `uint` overflow.
 
 #### `sub`
-Return `x - y` or an exception in case of `uint` overflow.
+Return `x - y` or an exception in case of `uint` underflow.
 
 #### `mul`
 Return `x * y` or an exception in case of `uint` overflow.


### PR DESCRIPTION
The description of the `sub` function makes mention of an overflow. When two values are substracted, an underflow can only occur. This is a very minor change and simply submitted for documentation consistency.