### PR TITLE
fix: :zap: modulus operator optimization

### DIFF
--- a/src/math.sol
+++ b/src/math.sol
@@ -75,12 +75,12 @@ contract DSMath {
     //    floor[(n-1) / 2] = floor[n / 2].
     //
     function rpow(uint x, uint n) internal pure returns (uint z) {
-        z = n % 2 != 0 ? x : RAY;
+        z = n & 1 != 0 ? x : RAY;
 
         for (n /= 2; n != 0; n /= 2) {
             x = rmul(x, x);
 
-            if (n % 2 != 0) {
+            if (n & 1 != 0) {
                 z = rmul(z, x);
             }
         }


### PR DESCRIPTION
Faster way to check if a value is even or odd, modulus "%" is quite expensive and an easily be replaced using bitwise operation